### PR TITLE
Fix horizontal spacing in dropdown item

### DIFF
--- a/internal/components/dropdown/dropdown.templ
+++ b/internal/components/dropdown/dropdown.templ
@@ -219,7 +219,7 @@ templ Item(props ...ItemProps) {
 			}
 			class={
 				utils.TwMerge(
-					"flex text-left items-center px-2 py-1.5 text-sm rounded-sm",
+					"flex text-left items-center justify-between px-2 py-1.5 text-sm rounded-sm",
 					utils.If(!p.Disabled, "focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground cursor-default"),
 					utils.If(p.Disabled, "opacity-50 pointer-events-none"),
 					p.Class,


### PR DESCRIPTION
The dropdown item component works fine with the usual button inside it, but when using the `Href` attribute, it uses a `<a>` instead of a button.

In which case, the tailwind classes were not quite the same (missing a `justify-between`).

Before:

<img width="179" height="186" alt="image" src="https://github.com/user-attachments/assets/d26ebc14-f0f4-41f7-995a-e8a31d21828d" />

After:

<img width="171" height="196" alt="image" src="https://github.com/user-attachments/assets/8a3b39b1-d842-42c7-a70e-64de4e079960" />
