### PR TITLE
fix: add input as selectbox dependency

### DIFF
--- a/internal/manifest.json
+++ b/internal/manifest.json
@@ -198,7 +198,7 @@
       "name": "selectbox",
       "description": "Dropdown selection menu",
       "files": ["internal/components/selectbox/selectbox.templ"],
-      "dependencies": ["button", "icon", "popover"],
+      "dependencies": ["button", "icon", "popover", "input"],
       "hasJS": true
     },
     {


### PR DESCRIPTION
Fixes #345 by adding input as selectbox dependency on manifest.json.