### PR TITLE
Making tabs scrollable in mobile

### DIFF
--- a/internal/components/tabs/tabs.templ
+++ b/internal/components/tabs/tabs.templ
@@ -70,7 +70,7 @@ templ List(props ...ListProps) {
 		}
 		class={
 			utils.TwMerge(
-				"relative flex items-center justify-center h-10 p-1 rounded-lg select-none bg-muted text-muted-foreground",
+				"relative flex items-center justify-start h-10 p-1 rounded-lg select-none bg-muted text-muted-foreground overflow-x-auto",
 				p.Class,
 			),
 		}


### PR DESCRIPTION
In outer containers with padding/margin, such as modal, tabs were cut and not shown fully.

Possible solution could be rendering tabs vertically, but I believe that it would take too much space. This leaves only logical solution as horizontally scrollable tabs.

Changes:

- Change class: 'justify-center' -> 'justify-start' corrects tabs list start cut off point. I attach the picture where you can see that start of the first tab is not rendered and not scrollable.
<img width="369" height="176" alt="image" src="https://github.com/user-attachments/assets/eaad62eb-32f1-4d4c-b342-0539b412bd2d" />

- Add class: 'overflow-x-auto' makes the tab list scrollable.