### PR TITLE
Fix calendar weeks

### DIFF
--- a/internal/components/calendar/calendar.js
+++ b/internal/components/calendar/calendar.js
@@ -68,7 +68,7 @@
       // Use days 0-6 (Sun-Sat standard). Intl provides names in the locale's typical order.
       dayNames = Array.from({ length: 7 }, (_, i) =>
         new Intl.DateTimeFormat(localeTag, { weekday: "short", timeZone: "UTC" }).format(
-          new Date(Date.UTC(2000, 0, i+2))
+          new Date(Date.UTC(2000, 0, i+2)) // +2 because Date.UTC(2000, 0, 0) actually returns 1999.12.31, which is a Friday
         )
       );
     } catch (e) {

--- a/internal/components/calendar/calendar.js
+++ b/internal/components/calendar/calendar.js
@@ -68,7 +68,7 @@
       // Use days 0-6 (Sun-Sat standard). Intl provides names in the locale's typical order.
       dayNames = Array.from({ length: 7 }, (_, i) =>
         new Intl.DateTimeFormat(localeTag, { weekday: "short" }).format(
-          new Date(Date.UTC(2000, 0, i))
+          new Date(Date.UTC(2000, 0, i+2))
         )
       );
     } catch (e) {

--- a/internal/components/calendar/calendar.js
+++ b/internal/components/calendar/calendar.js
@@ -67,7 +67,7 @@
     try {
       // Use days 0-6 (Sun-Sat standard). Intl provides names in the locale's typical order.
       dayNames = Array.from({ length: 7 }, (_, i) =>
-        new Intl.DateTimeFormat(localeTag, { weekday: "short" }).format(
+        new Intl.DateTimeFormat(localeTag, { weekday: "short", timeZone: "UTC" }).format(
           new Date(Date.UTC(2000, 0, i+2))
         )
       );


### PR DESCRIPTION
## The problem

<img width="519" height="355" alt="image" src="https://github.com/user-attachments/assets/b2f48147-893a-412b-8171-c610bb44f115" />

As one can see on the templui website, the weekdays name start on a Friday.

## The fix ?
I am going to try to explain the reasoning behind the changes I am submitting, because dates in JS are a notoriously difficult (see https://jsdate.wtf/ if you don't believe me).

Why do we have this behaviour?

This is because the calendar.js does this to transform the names to the wanted locale:

```js
   try {
      // Use days 0-6 (Sun-Sat standard). Intl provides names in the locale's typical order.
      dayNames = Array.from({ length: 7 }, (_, i) =>
        new Intl.DateTimeFormat(localeTag, { weekday: "short" }).format(
          new Date(Date.UTC(2000, 0, i))
        )
      );
    } catch (e) {
      console.error("Error generating calendar day names via Intl:", e);
      // Keep default dayNames on error
    }
```

As it turns out, if you create `new Date(Date.UTC(2000, 0, 0))` you will receive 1999.12.31, which is a Friday. To get the correct offset, we need to add 2 to get the desired Sunday.

Additionally, we need to specify the timezone as UTC, otherwise, `Intl` will get the timezone from the browser, which can potentially change the result.

<details><summary>See what happens with and without setting the timezone to UTC</summary>
<p>
Without, in San Francisco:

<img width="539" height="339" alt="image" src="https://github.com/user-attachments/assets/56eafbcb-0dc8-44aa-b637-a5c5982c072b" />

Without, in Berlin:

<img width="564" height="390" alt="image" src="https://github.com/user-attachments/assets/e22652c5-6355-42c9-b13b-82afdbccebf8" />

With the setting, in San Francisco:

<img width="591" height="371" alt="image" src="https://github.com/user-attachments/assets/2de21571-81dd-435b-ac20-f15c7197578d" />


With the setting, in Berlin:

<img width="608" height="337" alt="image" src="https://github.com/user-attachments/assets/adac1021-6f8c-43d1-a806-5225f13df92d" />


</p>
</details> 

My suggestion is to change the code to this:

```js
    try {
      // Use days 0-6 (Sun-Sat standard). Intl provides names in the locale's typical order.
      dayNames = Array.from({ length: 7 }, (_, i) =>
        new Intl.DateTimeFormat(localeTag, { weekday: "short", timeZone: "UTC" }).format(
          new Date(Date.UTC(2000, 0, i+2)) // +2 because Date.UTC(2000, 0, 0) actually returns 1999.12.31, which is a Friday
        )
      );
    } catch (e) {
      console.error("Error generating calendar day names via Intl:", e);
      // Keep default dayNames on error
    }
```

I will try to send a PR which will allow users to choose between Sunday as first day of week or Monday as first day of week. But that said, if we have to bias toward one or the other, I suggest biasing to Monday as start of week because ISO-8601 said so (see: [some preview of the spec I found](https://cdn.standards.iteh.ai/samples/40874/e4537809b46a40c3b1711fcb197559af/ISO-8601-2004.pdf) at section 2.2.8)

### Edit

The second PR is #362 . 