### PR TITLE
Allow choosing a starting day of week in calendar and datepicker

### DIFF
--- a/internal/components/calendar/calendar.js
+++ b/internal/components/calendar/calendar.js
@@ -33,6 +33,7 @@
     }
 
     const localeTag = container.getAttribute("data-tui-calendar-locale-tag") || "en-US";
+    const startOfWeek = parseInt(container.getAttribute("data-tui-calendar-start-of-week")) || 1; // 1 -> Monday
     let monthNames;
     try {
       monthNames = Array.from({ length: 12 }, (_, i) =>
@@ -68,7 +69,7 @@
       // Use days 0-6 (Sun-Sat standard). Intl provides names in the locale's typical order.
       dayNames = Array.from({ length: 7 }, (_, i) =>
         new Intl.DateTimeFormat(localeTag, { weekday: "short", timeZone: "UTC" }).format(
-          new Date(Date.UTC(2000, 0, i+2)) // +2 because Date.UTC(2000, 0, 0) actually returns 1999.12.31, which is a Friday
+          new Date(Date.UTC(2000, 0, i+2+startOfWeek)) // +2 because Date.UTC(2000, 0, 0) actually returns 1999.12.31, which is a Friday
         )
       );
     } catch (e) {
@@ -127,9 +128,9 @@
       daysContainer.innerHTML = "";
       const firstDayOfMonth = new Date(Date.UTC(currentYear, currentMonth, 1));
       const firstDayUTCDay = firstDayOfMonth.getUTCDay(); // 0=Sun
-      let startOffset = firstDayUTCDay; // Simple Sunday start offset
+      let startOffset = (((firstDayUTCDay - startOfWeek) % 7) + 7) % 7; // Always want a positive number
       // NOTE: A robust implementation might need to adjust offset based on locale's actual first day of week.
-      // Intl doesn't directly provide this easily yet. Keep Sunday start for simplicity.
+      // Intl doesn't directly provide this easily yet. In the meantime, allow user to pick.
 
       const daysInMonth = new Date(
         Date.UTC(currentYear, currentMonth + 1, 0)

--- a/internal/components/calendar/calendar.js
+++ b/internal/components/calendar/calendar.js
@@ -68,7 +68,7 @@
       // Use days 0-6 (Sun-Sat standard). Intl provides names in the locale's typical order.
       dayNames = Array.from({ length: 7 }, (_, i) =>
         new Intl.DateTimeFormat(localeTag, { weekday: "short", timeZone: "UTC" }).format(
-          new Date(Date.UTC(2000, 0, i+2))
+          new Date(Date.UTC(2000, 0, i+2)) // +2 because Date.UTC(2000, 0, 0) actually returns 1999.12.31, which is a Friday
         )
       );
     } catch (e) {

--- a/internal/components/calendar/calendar.js
+++ b/internal/components/calendar/calendar.js
@@ -68,7 +68,7 @@
       // Use days 0-6 (Sun-Sat standard). Intl provides names in the locale's typical order.
       dayNames = Array.from({ length: 7 }, (_, i) =>
         new Intl.DateTimeFormat(localeTag, { weekday: "short" }).format(
-          new Date(Date.UTC(2000, 0, i))
+          new Date(Date.UTC(2000, 0, i+2))
         )
       );
     } catch (e) {

--- a/internal/components/calendar/calendar.js
+++ b/internal/components/calendar/calendar.js
@@ -67,7 +67,7 @@
     try {
       // Use days 0-6 (Sun-Sat standard). Intl provides names in the locale's typical order.
       dayNames = Array.from({ length: 7 }, (_, i) =>
-        new Intl.DateTimeFormat(localeTag, { weekday: "short" }).format(
+        new Intl.DateTimeFormat(localeTag, { weekday: "short", timeZone: "UTC" }).format(
           new Date(Date.UTC(2000, 0, i+2))
         )
       );

--- a/internal/components/calendar/calendar.templ
+++ b/internal/components/calendar/calendar.templ
@@ -20,14 +20,27 @@ var (
 	LocaleTagSpanish    = LocaleTag("es-ES")
 )
 
+type Day int
+
+var (
+	Sunday    = Day(0)
+	Monday    = Day(1)
+	Tuesday   = Day(2)
+	Wednesday = Day(3)
+	Thursday  = Day(4)
+	Friday    = Day(5)
+	Saturday  = Day(6)
+)
+
 type Props struct {
 	ID           string
 	Class        string
 	LocaleTag    LocaleTag
 	Value        *time.Time
 	Name         string
-	InitialMonth int // Optional: 0-11 (Default: current or from Value). Controls the initially displayed month view.
-	InitialYear  int // Optional: (Default: current or from Value). Controls the initially displayed year view.
+	InitialMonth int  // Optional: 0-11 (Default: current or from Value). Controls the initially displayed month view.
+	InitialYear  int  // Optional: (Default: current or from Value). Controls the initially displayed year view.
+	StartOfWeek  *Day // Optional: 0-6 [Sun-Sat] (Default: 1).
 }
 
 templ Calendar(props ...Props) {
@@ -45,6 +58,11 @@ templ Calendar(props ...Props) {
 	}
 	if p.LocaleTag == "" {
 		p.LocaleTag = LocaleDefaultTag
+	}
+
+	initialStartOfWeek := Monday
+	if p.StartOfWeek != nil {
+		initialStartOfWeek = *p.StartOfWeek
 	}
 
 	initialView := time.Now()
@@ -86,6 +104,7 @@ templ Calendar(props ...Props) {
 			data-tui-calendar-initial-month={ strconv.Itoa(initialMonth) }
 			data-tui-calendar-initial-year={ strconv.Itoa(initialYear) }
 			data-tui-calendar-selected-date={ initialSelectedISO }
+			data-tui-calendar-start-of-week={ int(initialStartOfWeek) }
 		>
 			<!-- Calendar Header -->
 			<div class="flex items-center justify-between mb-4">

--- a/internal/components/datepicker/datepicker.templ
+++ b/internal/components/datepicker/datepicker.templ
@@ -37,8 +37,9 @@ type Props struct {
 	Class       string
 	Attributes  templ.Attributes
 	Value       time.Time
-	Format      Format    // Controls the display format using Intl dateStyle options.
-	LocaleTag   LocaleTag // BCP 47 Locale Tag (e.g., "en-US", "es-ES"). Determines language and regional format defaults.
+	Format      Format        // Controls the display format using Intl dateStyle options.
+	LocaleTag   LocaleTag     // BCP 47 Locale Tag (e.g., "en-US", "es-ES"). Determines language and regional format defaults.
+	StartOfWeek *calendar.Day // Optional: 0-6 [Sun-Sat] (Default: 1).
 	Placeholder string
 	Disabled    bool
 	Required    bool
@@ -96,11 +97,11 @@ templ DatePicker(props ...Props) {
 			),
 			Disabled: p.Disabled,
 			Attributes: utils.MergeAttributes(p.Attributes, templ.Attributes{
-				"data-tui-datepicker":     "true",
+				"data-tui-datepicker":                "true",
 				"data-tui-datepicker-display-format": string(p.Format),
 				"data-tui-datepicker-locale-tag":     string(p.LocaleTag),
 				"data-tui-datepicker-placeholder":    p.Placeholder,
-				"aria-invalid":        utils.If(p.HasError, "true"),
+				"aria-invalid":                       utils.If(p.HasError, "true"),
 			}),
 		}) {
 			if p.Placeholder != "" {
@@ -125,10 +126,11 @@ templ DatePicker(props ...Props) {
 				Class: "p-3",
 			}) {
 				@calendar.Calendar(calendar.Props{
-					ID:        p.ID + "-calendar-instance",     // Pass ID for calendar instance
-					Name:      p.Name,                          // Pass Name for hidden input
-					LocaleTag: calendar.LocaleTag(p.LocaleTag), // Pass locale tag to calendar
-					Value:     valuePtr,                        // Pass pointer to value
+					ID:          p.ID + "-calendar-instance",     // Pass ID for calendar instance
+					Name:        p.Name,                          // Pass Name for hidden input
+					LocaleTag:   calendar.LocaleTag(p.LocaleTag), // Pass locale tag to calendar
+					StartOfWeek: p.StartOfWeek,                   // Pass start of week to calendar
+					Value:       valuePtr,                        // Pass pointer to value
 				})
 			}
 		}

--- a/internal/ui/pages/calendar.templ
+++ b/internal/ui/pages/calendar.templ
@@ -120,6 +120,13 @@ templ Calendar() {
 								Description: "Initial year to display. Defaults to current year or Value's year.",
 								Required:    false,
 							},
+							{
+								Name:        "StartOfWeek",
+								Type:        "*Day",
+								Default:     "nil",
+								Description: "Optional start of week (0-6, Sun-Sat). When nil, defaults to Monday (1). Use calendar.Sunday through calendar.Saturday constants.",
+								Required:    false,
+							},
 						},
 					})
 				</div>

--- a/internal/ui/pages/date_picker.templ
+++ b/internal/ui/pages/date_picker.templ
@@ -59,7 +59,7 @@ templ DatePicker() {
 	) {
 		@modules.PageWrapper(modules.PageWrapperProps{
 			Name:        "Date Picker",
-			Description: templ.Raw("Calendar interface for selecting and formatting dates. Uses <a href='/docs/components/popover' class='text-primary underline underline-offset-2 hover:opacity-80 transition-opacity'>Popover</a> for the popup."),
+			Description: templ.Raw("Calendar interface for selecting and formatting dates. Uses <a href='/docs/components/calendar' class='text-primary underline underline-offset-2 hover:opacity-80 transition-opacity'>Calendar</a> for date selection and <a href='/docs/components/popover' class='text-primary underline underline-offset-2 hover:opacity-80 transition-opacity'>Popover</a> for the popup."),
 			Tailwind:    true,
 			VanillaJS:   true,
 			Breadcrumbs: modules.Breadcrumbs{
@@ -177,6 +177,12 @@ templ DatePicker() {
 								Type:        "LocaleTag",
 								Default:     "en-US",
 								Description: "BCP 47 Locale Tag for language and regional format",
+							},
+							{
+								Name:        "StartOfWeek",
+								Type:        "*calendar.Day",
+								Default:     "nil",
+								Description: "Optional start of week passed to Calendar component. When nil, Calendar defaults to Monday. Use calendar.Sunday through calendar.Saturday constants.",
 							},
 							{
 								Name:        "Placeholder",


### PR DESCRIPTION
For more info, read https://github.com/templui/templui/pull/361 first.

This PR allows the user to choose the default start of the week for the calendar and datepicker.

As I suggested in #361, I set the default to Monday. If that is not the default setting we want, we can change it.

Example of the result in a `DatePicker` with Saturday selected as the first day of week with a locale in french:

<img width="317" height="365" alt="image" src="https://github.com/user-attachments/assets/a1dd78f7-c39e-46cd-af71-865800d8d262" />

---

Notes:
1. I suggest that we squash the changes to keep things simple.
2. I based this PR on my previous PR #361, merging it will merge both changes.
3. I know that this isn't ideal and the we would want the default start of week to be defined by the locale, but this allows us to have a functional component without waiting on the JS to bumble its way to having a decent Date API.