### PR TITLE
Fix datepicker usage in form

### DIFF
--- a/internal/components/datepicker/datepicker.js
+++ b/internal/components/datepicker/datepicker.js
@@ -69,20 +69,19 @@
     if (!triggerButton || triggerButton.hasAttribute("data-tui-datepicker-initialized")) return;
     triggerButton.setAttribute("data-tui-datepicker-initialized", "true");
 
+    let hiddenInput = triggerButton.querySelector("[data-tui-datepicker-hidden-input]");
+
     const datePickerID = triggerButton.id;
     const displaySpan = triggerButton.querySelector(
       "[data-tui-datepicker-display]"
     );
     const calendarInstanceId = datePickerID + "-calendar-instance";
     const calendarInstance = document.getElementById(calendarInstanceId);
-    const calendarHiddenInputId = calendarInstanceId + "-hidden";
-    const calendarHiddenInput = document.getElementById(calendarHiddenInputId);
 
     // Fallback to find calendar relatively
     let calendar = calendarInstance;
-    let hiddenInput = calendarHiddenInput;
 
-    if (!calendarInstance || !calendarHiddenInput) {
+    if (!calendarInstance) {
       const popoverContentId = triggerButton.getAttribute("aria-controls");
       const popoverContent = popoverContentId
         ? document.getElementById(popoverContentId)
@@ -90,14 +89,6 @@
       if (popoverContent) {
         if (!calendar)
           calendar = popoverContent.querySelector("[data-tui-calendar-container]");
-        if (!hiddenInput) {
-          const wrapper = popoverContent.querySelector(
-            "[data-tui-calendar-wrapper]"
-          );
-          hiddenInput = wrapper
-            ? wrapper.querySelector("[data-tui-calendar-hidden-input]")
-            : null;
-        }
       }
     }
 
@@ -131,6 +122,11 @@
       );
       displaySpan.textContent = displayFormattedValue;
       displaySpan.classList.remove("text-muted-foreground");
+
+      // Update hidden input
+      const isoFormattedValue = selectedDate.toISOString().split("T")[0];
+      hiddenInput.value = isoFormattedValue;
+      hiddenInput.disabled = false; // add the input to the form
 
       // Find and click the popover trigger to close it
       const popoverTrigger = triggerButton

--- a/internal/components/datepicker/datepicker.templ
+++ b/internal/components/datepicker/datepicker.templ
@@ -96,11 +96,11 @@ templ DatePicker(props ...Props) {
 			),
 			Disabled: p.Disabled,
 			Attributes: utils.MergeAttributes(p.Attributes, templ.Attributes{
-				"data-tui-datepicker":     "true",
+				"data-tui-datepicker":                "true",
 				"data-tui-datepicker-display-format": string(p.Format),
 				"data-tui-datepicker-locale-tag":     string(p.LocaleTag),
 				"data-tui-datepicker-placeholder":    p.Placeholder,
-				"aria-invalid":        utils.If(p.HasError, "true"),
+				"aria-invalid":                       utils.If(p.HasError, "true"),
 			}),
 		}) {
 			if p.Placeholder != "" {
@@ -111,6 +111,17 @@ templ DatePicker(props ...Props) {
 			<span class="text-muted-foreground flex items-center ml-2">
 				@icon.Calendar(icon.Props{Size: 16})
 			</span>
+			// hidden input for form
+			// initially marked as disabled to prevent double sending of value
+			// because the calendar hidden input is visible before the user clicks on the popover
+			<input
+				type="hidden"
+				name={ p.Name }
+				value={ p.Value.Format("2006-01-02") }
+				id={ p.ID + "-hidden" }
+				disabled
+				data-tui-datepicker-hidden-input
+			/>
 		}
 	}
 	@popover.Content(popover.ContentProps{


### PR DESCRIPTION
The datepicker is great, but it doesn't always work in forms.

There are two cases:
1. The user has not clicked on the `popover.Trigger`, in which case, the hidden input from the calendar is in the DOM as a child of the form. => it works
2. The use has clicked on the `popover.Trigger`, in which case, the calendar has moved its contents in the `popover.Content`, outside of the form. Thus, the hidden calendar input is not a child of the form and is not sent. => it doesn't work

What I did to fix that is:
1. Add a hidden input for the datepicker, which is marked as disabled. This prevents a double sending of the value if the user never clicks on the `popover.Trigger`.
2. In the JS, when we have a new value for the selected date, update the hidden input and remove the disabled attribute. This allows the form to contain at least one input with a correct value.

I am not the most familiar with the internal structure of all our components, so if there's a better way to do this, please let me know.

Cheers,

GLS 