### PR TITLE
UX: ignore toggle password button in password input when navigating with tab

### DIFF
--- a/internal/components/input/input.templ
+++ b/internal/components/input/input.templ
@@ -108,7 +108,7 @@ templ Input(props ...Props) {
 				Size:       button.SizeIcon,
 				Variant:    button.VariantGhost,
 				Class:      "absolute right-0 top-1/2 -translate-y-1/2 opacity-50 cursor-pointer",
-				Attributes: templ.Attributes{"data-tui-input-toggle-password": p.ID},
+				Attributes: templ.Attributes{"data-tui-input-toggle-password": p.ID, "tabindex": -1},
 			}) {
 				<span class="icon-open block">
 					@icon.Eye(icon.Props{


### PR DESCRIPTION
### Overview
UX: add tabindex of -1 to password toggle button in input component

### Description

This update removes the toggle password visibility button (the little "eye" icon) from the keyboard tab order.

Previously, when navigating a form with Tab, focus would stop on the toggle button after the password input. This created an extra step for users who rely on keyboard navigation.

By setting tabindex="-1" on the toggle button, it is now skipped during tab navigation, but remains clickable with a mouse or tappable on touch devices.


### Changes Made

- Added tabindex="-1" to the password visibility toggle button.
- No visual/UI changes.
- Behavior of the button remains unchanged for mouse/touch users.
