### PR TITLE
Add tabindex -1 to prevent focus on password input icons

### DIFF
--- a/internal/components/input/input.templ
+++ b/internal/components/input/input.templ
@@ -108,7 +108,7 @@ templ Input(props ...Props) {
 				Size:       button.SizeIcon,
 				Variant:    button.VariantGhost,
 				Class:      "absolute right-0 top-1/2 -translate-y-1/2 opacity-50 cursor-pointer",
-				Attributes: templ.Attributes{"data-tui-input-toggle-password": p.ID},
+				Attributes: templ.Attributes{"data-tui-input-toggle-password": p.ID, "tabindex": "-1"},
 			}) {
 				<span class="icon-open block">
 					@icon.Eye(icon.Props{


### PR DESCRIPTION
Fixes #416. Adding a tabindex of -1 prevents the focus on the icon, so one can directly move to the next input when pressing the tab button.