### PR TITLE
By default bust the cache on each git commit or UNIX timestamp if git is not available

### DIFF
--- a/cmd/templui/main.go
+++ b/cmd/templui/main.go
@@ -1093,6 +1093,11 @@ func addScriptTemplateToFiles(config Config, comp ComponentDef, jsFileName strin
 			webPath = "/" + filepath.ToSlash(filepath.Join(config.JSDir, jsFileName))
 		}
 
+		// Create the project path for the JavaScript file
+		// Always use the relative project path for the JavaScript file
+		var projectPath string
+		projectPath = filepath.ToSlash(filepath.Join(config.JSDir, jsFileName))
+
 		// Check if Script() template already exists
 		if strings.Contains(contentStr, "templ Script()") {
 			fmt.Printf("   Script() template already exists in %s\n", destPath)
@@ -1100,9 +1105,9 @@ func addScriptTemplateToFiles(config Config, comp ComponentDef, jsFileName strin
 		}
 
 		// Create the Script() template with correct templ syntax and nonce support
-		scriptTemplate := fmt.Sprintf(`templ Script() {
-	<script defer nonce={ templ.GetNonce(ctx) } src="%s"></script>
-}`, webPath)
+		scriptTemplate := `templ Script() {
+			<script defer nonce={ templ.GetNonce(ctx) } src={ fmt.Sprintf("` + webPath + `?v=%s", utils.FileVersion("` + projectPath + `")) }></script>
+		}`
 
 		// Add Script() template at the end
 		newContent := strings.TrimSpace(contentStr) + "\n\n" + scriptTemplate + "\n"

--- a/internal/ui/pages/how_to_use.templ
+++ b/internal/ui/pages/how_to_use.templ
@@ -200,7 +200,7 @@ var devCommand = `make dev`
 
 var configurationFile = `{
   "componentsDir": "components",
-  "utilsDir": "utils", 
+  "utilsDir": "utils",
   "moduleName": "your-app/module",
   "jsDir": "assets/js",
   "jsPublicPath": "/assets/js"
@@ -215,7 +215,7 @@ mux.Handle("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("./
   "jsPublicPath": "/assets/js"  // or omit for automatic fallback
 }`
 
-var urlPrefixSetup = `// Go server setup  
+var urlPrefixSetup = `// Go server setup
 appGroup := mux.PathPrefix("/app").Subrouter()
 appGroup.Handle("/static/", http.StripPrefix("/app/static/", http.FileServer(http.Dir("./assets"))))
 
@@ -228,7 +228,7 @@ appGroup.Handle("/static/", http.StripPrefix("/app/static/", http.FileServer(htt
 var customAssetSetup = `// Go server setup
 mux.Handle("/public/", http.StripPrefix("/public/", http.FileServer(http.Dir("./build"))))
 
-// .templui.json  
+// .templui.json
 {
   "jsDir": "build/js",
   "jsPublicPath": "/public/js"
@@ -318,7 +318,7 @@ templ HowToUse() {
 								CodeContent:    installGo,
 							})
 							<p class="text-sm mt-2 text-muted-foreground">
-								For installation instructions, visit 
+								For installation instructions, visit
 								<a href="https://golang.org/dl" class="inline-flex items-center gap-1 text-primary/90 hover:text-primary underline underline-offset-4" target="_blank">
 									golang.org/dl
 									@icon.ArrowUpRight(icon.Props{Size: 12})
@@ -559,6 +559,7 @@ templ HowToUse() {
 									CodeContent:    "@dialog.Script()  // Include in your base layout",
 								})
 								<p class="text-sm mt-2 text-muted-foreground">Each component manages its own JavaScript - no global bundle needed!</p>
+								<p class="text-sm mt-2 text-muted-foreground">JavaScript files have their cache busted based on their git commit hash or current timestamp if git hash is not available.</p>
 							</div>
 						</div>
 						<div id="update-components">

--- a/internal/utils/templui.go
+++ b/internal/utils/templui.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"fmt"
+	"os/exec"
+	"time"
 
 	"crypto/rand"
 
@@ -51,4 +53,16 @@ func MergeAttributes(attrs ...templ.Attributes) templ.Attributes {
 // Example: RandomID() → "id-1a2b3c"
 func RandomID() string {
 	return fmt.Sprintf("id-%s", rand.Text())
+}
+
+// FileVersion returns the last commit hash of a file change using Git.
+// Example: FileVersion("internal/web/static/js/carousel.min.js") -> "5632101539fef5aaad8cc01690698c1c3a0f496c"
+func FileVersion(projectPath string) string {
+	cmd := exec.Command("git", "log", "-1", "--format=%H", "--", projectPath)
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Sprintf("%d", time.Now().Unix())
+	} else {
+		return string(output)
+	}
 }


### PR DESCRIPTION
Fixes issue #390

I thought a bit and as I mentioned the perfect solution is to determine if the script file has actually been changed.

I am not fully sure if using `git` is the best choice, but most projects have it initialized.

Let's discuss if there could be a more robust way of doing that.

Regarding addition in utils package, as I understand from the source, pushing that to git would automatically download the utils when upgrading?