### PR TITLE
refactor!: remove Required prop from form components

### DIFF
--- a/internal/components/checkbox/checkbox.templ
+++ b/internal/components/checkbox/checkbox.templ
@@ -12,7 +12,6 @@ type Props struct {
 	Name       string
 	Value      string
 	Disabled   bool
-	Required   bool
 	Checked    bool
 	Form       string
 	Icon       templ.Component
@@ -27,8 +26,7 @@ templ Checkbox(props ...Props) {
 		<input
 			checked?={ p.Checked }
 			disabled?={ p.Disabled }
-			required?={ p.Required }
-			if p.ID != "" {
+					if p.ID != "" {
 				id={ p.ID }
 			}
 			if p.Name != "" {

--- a/internal/components/datepicker/datepicker.templ
+++ b/internal/components/datepicker/datepicker.templ
@@ -44,7 +44,6 @@ type Props struct {
 	StartOfWeek *calendar.Day // Optional: 0-6 [Sun-Sat] (Default: 1).
 	Placeholder string
 	Disabled    bool
-	Required    bool
 	HasError    bool
 }
 

--- a/internal/components/input/input.templ
+++ b/internal/components/input/input.templ
@@ -36,7 +36,6 @@ type Props struct {
 	Value            string
 	Disabled         bool
 	Readonly         bool
-	Required         bool
 	FileAccept       string
 	HasError         bool
 	NoTogglePassword bool
@@ -74,8 +73,7 @@ templ Input(props ...Props) {
 			}
 			disabled?={ p.Disabled }
 			readonly?={ p.Readonly }
-			required?={ p.Required }
-			if p.HasError {
+					if p.HasError {
 				aria-invalid="true"
 			}
 			class={

--- a/internal/components/inputotp/inputotp.templ
+++ b/internal/components/inputotp/inputotp.templ
@@ -10,7 +10,6 @@ type Props struct {
 	Class      string
 	Attributes templ.Attributes
 	Value      string
-	Required   bool
 	Name       string
 	Form       string
 	HasError   bool
@@ -75,8 +74,7 @@ templ InputOTP(props ...Props) {
 				aria-invalid="true"
 			}
 			data-tui-inputotp-value-target
-			required?={ p.Required }
-		/>
+			/>
 		{ children... }
 	</div>
 }

--- a/internal/components/radio/radio.templ
+++ b/internal/components/radio/radio.templ
@@ -10,7 +10,6 @@ type Props struct {
 	Value      string
 	Form       string
 	Disabled   bool
-	Required   bool
 	Checked    bool
 }
 
@@ -35,8 +34,7 @@ templ Radio(props ...Props) {
 		}
 		checked?={ p.Checked }
 		disabled?={ p.Disabled }
-		required?={ p.Required }
-		class={
+			class={
 			utils.TwMerge(
 				"relative h-4 w-4",
 				"before:absolute before:left-1/2 before:top-1/2",

--- a/internal/components/selectbox/selectbox.templ
+++ b/internal/components/selectbox/selectbox.templ
@@ -28,7 +28,6 @@ type TriggerProps struct {
 	Attributes        templ.Attributes
 	Name              string
 	Form              string
-	Required          bool
 	Disabled          bool
 	HasError          bool
 	Multiple          bool
@@ -143,8 +142,7 @@ templ Trigger(props ...TriggerProps) {
 					"data-tui-selectbox-show-pills":          strconv.FormatBool(p.ShowPills),
 					"data-tui-selectbox-selected-count-text": p.SelectedCountText,
 					"tabindex":                               "0",
-					"required":                               strconv.FormatBool(p.Required),
-					"aria-invalid":                           utils.If(p.HasError, "true"),
+						"aria-invalid":                           utils.If(p.HasError, "true"),
 				},
 			),
 		}) {
@@ -156,8 +154,7 @@ templ Trigger(props ...TriggerProps) {
 				if p.Form != "" {
 					form={ p.Form }
 				}
-				required?={ p.Required }
-				{ p.Attributes... }
+						{ p.Attributes... }
 			/>
 			{ children... }
 			<span class="pointer-events-none ml-1">

--- a/internal/components/textarea/textarea.templ
+++ b/internal/components/textarea/textarea.templ
@@ -16,7 +16,6 @@ type Props struct {
 	Rows        int
 	AutoResize  bool
 	Disabled    bool
-	Required    bool
 	Readonly    bool
 	HasError    bool
 }
@@ -45,8 +44,7 @@ templ Textarea(props ...Props) {
 			rows={ strconv.Itoa(p.Rows) }
 		}
 		disabled?={ p.Disabled }
-		required?={ p.Required }
-		readonly?={ p.Readonly }
+			readonly?={ p.Readonly }
 		if p.HasError {
 			aria-invalid="true"
 		}

--- a/internal/components/timepicker/timepicker.templ
+++ b/internal/components/timepicker/timepicker.templ
@@ -25,7 +25,6 @@ type Props struct {
 	AMLabel     string
 	PMLabel     string
 	Placeholder string
-	Required    bool
 	Disabled    bool
 	HasError    bool
 }
@@ -77,8 +76,7 @@ templ TimePicker(props ...Props) {
 			if p.Form != "" {
 				form={ p.Form }
 			}
-			required?={ p.Required }
-			id={ p.ID + "-hidden" }
+				id={ p.ID + "-hidden" }
 			data-tui-timepicker-hidden-input="true"
 		/>
 		@popover.Trigger(popover.TriggerProps{For: contentID}) {

--- a/internal/ui/pages/checkbox.templ
+++ b/internal/ui/pages/checkbox.templ
@@ -133,13 +133,6 @@ templ Checkbox() {
 								Required:    false,
 							},
 							{
-								Name:        "Required",
-								Type:        "bool",
-								Default:     "false",
-								Description: "Whether the checkbox is required for form submission.",
-								Required:    false,
-							},
-							{
 								Name:        "Checked",
 								Type:        "bool",
 								Default:     "false",

--- a/internal/ui/pages/date_picker.templ
+++ b/internal/ui/pages/date_picker.templ
@@ -207,12 +207,6 @@ templ DatePicker() {
 								Description: "Whether the date picker is disabled",
 							},
 							{
-								Name:        "Required",
-								Type:        "bool",
-								Default:     "false",
-								Description: "Whether the date picker is required for form validation",
-							},
-							{
 								Name:        "HasError",
 								Type:        "bool",
 								Default:     "false",

--- a/internal/ui/pages/input-otp.templ
+++ b/internal/ui/pages/input-otp.templ
@@ -179,12 +179,6 @@ templ InputOtp() {
 								Description: "Current value of the OTP input",
 							},
 							{
-								Name:        "Required",
-								Type:        "bool",
-								Default:     "false",
-								Description: "Whether the OTP input is required for form validation",
-							},
-							{
 								Name:        "Name",
 								Type:        "string",
 								Default:     "\"\"",

--- a/internal/ui/pages/input.templ
+++ b/internal/ui/pages/input.templ
@@ -216,13 +216,6 @@ templ Input() {
 								Required:    false,
 							},
 							{
-								Name:        "Required",
-								Type:        "bool",
-								Default:     "false",
-								Description: "Whether the input is required for form submission.",
-								Required:    false,
-							},
-							{
 								Name:        "FileAccept",
 								Type:        "string",
 								Default:     "",

--- a/internal/ui/pages/radio.templ
+++ b/internal/ui/pages/radio.templ
@@ -133,13 +133,6 @@ templ Radio() {
 								Required:    false,
 							},
 							{
-								Name:        "Required",
-								Type:        "bool",
-								Default:     "false",
-								Description: "Whether the radio button is required for form submission.",
-								Required:    false,
-							},
-							{
 								Name:        "Checked",
 								Type:        "bool",
 								Default:     "false",

--- a/internal/ui/pages/select_box.templ
+++ b/internal/ui/pages/select_box.templ
@@ -231,13 +231,6 @@ templ SelectBox() {
 								Required:    false,
 							},
 							{
-								Name:        "Required",
-								Type:        "bool",
-								Default:     "false",
-								Description: "Whether the select field is required for form validation.",
-								Required:    false,
-							},
-							{
 								Name:        "Disabled",
 								Type:        "bool",
 								Default:     "false",

--- a/internal/ui/pages/textarea.templ
+++ b/internal/ui/pages/textarea.templ
@@ -196,13 +196,6 @@ templ Textarea() {
 								Required:    false,
 							},
 							{
-								Name:        "Required",
-								Type:        "bool",
-								Default:     "false",
-								Description: "Whether the textarea is required for form submission.",
-								Required:    false,
-							},
-							{
 								Name:        "ReadOnly",
 								Type:        "bool",
 								Default:     "false",

--- a/internal/ui/pages/time_picker.templ
+++ b/internal/ui/pages/time_picker.templ
@@ -237,13 +237,6 @@ templ TimePicker() {
 								Required:    false,
 							},
 							{
-								Name:        "Required",
-								Type:        "bool",
-								Default:     "false",
-								Description: "Whether the time picker is required for form submission.",
-								Required:    false,
-							},
-							{
 								Name:        "Disabled",
 								Type:        "bool",
 								Default:     "false",

--- a/internal/ui/showcase/input_otp_form.templ
+++ b/internal/ui/showcase/input_otp_form.templ
@@ -14,7 +14,6 @@ templ InputOTPForm() {
 		}
 		@inputotp.InputOTP(inputotp.Props{
 			ID:       "otp-form",
-			Required: true,
 			HasError: true,
 		}) {
 			@inputotp.Group() {

--- a/internal/ui/showcase/input_otp_with_label.templ
+++ b/internal/ui/showcase/input_otp_with_label.templ
@@ -12,7 +12,6 @@ templ InputOTPWithLabel() {
 		}
 		@inputotp.InputOTP(inputotp.Props{
 			ID:       "otp-with-label",
-			Required: true,
 			HasError: true,
 		}) {
 			@inputotp.Group() {

--- a/internal/ui/showcase/select_box_form.templ
+++ b/internal/ui/showcase/select_box_form.templ
@@ -17,8 +17,7 @@ templ SelectBoxForm() {
 				@selectbox.Trigger(selectbox.TriggerProps{
 					ID:       "select-form",
 					Name:     "fruit",
-					Required: true,
-					HasError: true,
+						HasError: true,
 				}) {
 					@selectbox.Value(selectbox.ValueProps{
 						Placeholder: "Select a fruit",


### PR DESCRIPTION
Remove Required prop from all form components (input, checkbox, radio, textarea, selectbox, inputotp, timepicker, datepicker) in favor of SSR-first validation approach.

The Required prop was redundant as:

* Server must validate all inputs regardless
* Browser validation doesn't work with hidden inputs (selectbox, inputotp, etc.)
* Creates confusion about validation responsibility

BREAKING CHANGE: Required prop no longer available on form components. Server-side validation is now the only validation approach.