### PR TITLE
feat(input): add Required field to Input component Props

### DIFF
--- a/internal/components/input/input.templ
+++ b/internal/components/input/input.templ
@@ -36,6 +36,7 @@ type Props struct {
 	Value            string
 	Disabled         bool
 	Readonly         bool
+	Required         bool
 	FileAccept       string
 	HasError         bool
 	NoTogglePassword bool
@@ -73,6 +74,7 @@ templ Input(props ...Props) {
 			}
 			disabled?={ p.Disabled }
 			readonly?={ p.Readonly }
+			required?={ p.Required }
 			if p.HasError {
 				aria-invalid="true"
 			}


### PR DESCRIPTION
**Description:**

Closes #507

Adds a `Required bool` field to the Input component's `Props` struct and renders it as the native HTML `required` attribute on the `<input>` element.

This brings `Required` in line with the existing `Disabled` and `Readonly` first-class props. Since the Input component renders a standard `<input>` element, native browser constraint validation works as expected — no hidden-input caveats apply.

**Before (workaround via Attributes):**
```go
input.Input(input.Props{
    Attributes: templ.Attributes{"required": true},
})
```

**After:**
```go
input.Input(input.Props{
    Required: true,
})
```